### PR TITLE
feat: call populate-pr-description from github-actions

### DIFF
--- a/.github/workflows/populate-pr-description.yml
+++ b/.github/workflows/populate-pr-description.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/populate-pr-description
+      - uses: turboBasic/github-actions/actions/populate-pr-description@v2
         with:
           github-token: ${{ github.token }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

- feat: call populate-pr-description from github-actions

## Changes

- **feat: call populate-pr-description from github-actions**

  Points the workflow at turboBasic/github-actions/actions/populate-pr-description@v2

  instead of the local copy under .github/actions/. Inputs are unchanged: the shared

  action takes the same five and adds an optional template-path defaulting to the

  path used here.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [ ] Manually verified

## Checklist

- [ ] No secrets or credentials included
- [ ] `make lint` passes locally