### PR TITLE
chore(claude): enable the hygiene plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,5 +33,16 @@
       "Bash(git tag:*)",
       "Bash(git stash drop:*)"
     ]
+  },
+  "enabledPlugins": {
+    "hygiene@turbobasic": true
+  },
+  "extraKnownMarketplaces": {
+    "turbobasic": {
+      "source": {
+        "source": "github",
+        "repo": "turboBasic/claude-plugins"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

- chore(claude): enable the hygiene plugin

## Changes

- **chore(claude): enable the hygiene plugin**

  Registers the turbobasic marketplace and enables hygiene at project

  scope, installed once here because declaring a plugin in enabledPlugins

  fetches it but does not load it.

  Nothing local is superseded: this repo's only skill is

  terminal-output-fallback, so housekeeping and update-docs are both new.

  The doc-lookup plugins its plan row also listed are enabled at user

  scope already and are not repeated here.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally